### PR TITLE
Updates to HISAT2 run

### DIFF
--- a/kb_hisat2.spec
+++ b/kb_hisat2.spec
@@ -9,9 +9,11 @@ module kb_hisat2 {
 /*
     Input for hisat2.
     ws_name = the workspace name provided by the narrative for storing output.
-    sampleset_ref = the workspace reference for the sampleset of reads to align.
+    sampleset_ref = the workspace reference for either the reads library or set of reads libraries to align.
+                  accepted types: KBaseSets.ReadsSet, KBaseRNASeq.RNASeqSampleSet,
+                                  KBaseAssembly.SingleEndLibrary, KBaseAssembly.PairedEndLibrary,
+                                  KBaseFile.SingleEndLibrary, KBaseFile.PairedEndLibrary
     genome_ref = the workspace reference for the reference genome that HISAT2 will align against.
-    alignmentset_name = the name of the alignment set object to create.
     num_threads = the number of threads to tell hisat to use (default 2)
     quality_score = one of phred33 or phred64
     skip = number of initial reads to skip (default 0)
@@ -29,10 +31,15 @@ module kb_hisat2 {
     condition = a string stating the experimental condition of the reads. REQUIRED for single reads,
                 ignored for sets.
     build_report = 1 if we build a report, 0 otherwise. (default 1) (shouldn't be user set - mainly used for subtasks)
+    output naming:
+        alignment_suffix is appended to the name of each individual reads object name (just the one if
+        it's a simple input of a single reads library, but to each if it's a set)
+        alignmentset_suffix is appended to the name of the reads set, if a set is passed.
 */
     typedef structure {
         string ws_name;
-        string alignmentset_name;
+        string alignment_suffix;
+        string alignmentset_suffix;
         string sampleset_ref;
         string condition;
         string genome_ref;
@@ -53,14 +60,28 @@ module kb_hisat2 {
         bool build_report;
     } Hisat2Params;
 
+
+/*
+    Created alignment object returned.
+    alignment_ref = the workspace reference of the new alignment object
+    name = the name of the new object, for convenience.
+*/
+    typedef structure {
+        string alignment_ref;
+        string name;
+    } AlignmentObj;
+
 /*
     Output for hisat2.
-    alignment_ref: can be either an Alignment or AlignmentSet, depending on inputs.
+    alignmentset_ref if an alignment set is created
+    alignment_objs for each individual alignment created. The keys are the references to the reads
+        object being aligned.
 */
     typedef structure {
 		string report_name;
 		string report_ref;
-        string alignment_ref;
+        string alignmentset_ref;
+        mapping<string reads_ref, AlignmentObj> alignment_objs;
     } Hisat2Output;
 
     funcdef run_hisat2(Hisat2Params params)

--- a/kbase.yml
+++ b/kbase.yml
@@ -8,7 +8,7 @@ service-language:
     python
 
 module-version:
-    0.1.10
+    0.2.0
 
 owners:
     [wjriehl]

--- a/lib/kb_hisat2/kb_hisat2Client.pm
+++ b/lib/kb_hisat2/kb_hisat2Client.pm
@@ -123,7 +123,8 @@ $params is a kb_hisat2.Hisat2Params
 $return is a kb_hisat2.Hisat2Output
 Hisat2Params is a reference to a hash where the following keys are defined:
 	ws_name has a value which is a string
-	alignmentset_name has a value which is a string
+	alignment_suffix has a value which is a string
+	alignmentset_suffix has a value which is a string
 	sampleset_ref has a value which is a string
 	condition has a value which is a string
 	genome_ref has a value which is a string
@@ -141,11 +142,16 @@ Hisat2Params is a reference to a hash where the following keys are defined:
 	no_spliced_alignment has a value which is a kb_hisat2.bool
 	transcriptome_mapping_only has a value which is a kb_hisat2.bool
 	tailor_alignments has a value which is a string
+	build_report has a value which is a kb_hisat2.bool
 bool is an int
 Hisat2Output is a reference to a hash where the following keys are defined:
 	report_name has a value which is a string
 	report_ref has a value which is a string
+	alignmentset_ref has a value which is a string
+	alignment_objs has a value which is a reference to a hash where the key is a string and the value is a kb_hisat2.AlignmentObj
+AlignmentObj is a reference to a hash where the following keys are defined:
 	alignment_ref has a value which is a string
+	name has a value which is a string
 
 </pre>
 
@@ -157,7 +163,8 @@ $params is a kb_hisat2.Hisat2Params
 $return is a kb_hisat2.Hisat2Output
 Hisat2Params is a reference to a hash where the following keys are defined:
 	ws_name has a value which is a string
-	alignmentset_name has a value which is a string
+	alignment_suffix has a value which is a string
+	alignmentset_suffix has a value which is a string
 	sampleset_ref has a value which is a string
 	condition has a value which is a string
 	genome_ref has a value which is a string
@@ -175,11 +182,16 @@ Hisat2Params is a reference to a hash where the following keys are defined:
 	no_spliced_alignment has a value which is a kb_hisat2.bool
 	transcriptome_mapping_only has a value which is a kb_hisat2.bool
 	tailor_alignments has a value which is a string
+	build_report has a value which is a kb_hisat2.bool
 bool is an int
 Hisat2Output is a reference to a hash where the following keys are defined:
 	report_name has a value which is a string
 	report_ref has a value which is a string
+	alignmentset_ref has a value which is a string
+	alignment_objs has a value which is a reference to a hash where the key is a string and the value is a kb_hisat2.AlignmentObj
+AlignmentObj is a reference to a hash where the following keys are defined:
 	alignment_ref has a value which is a string
+	name has a value which is a string
 
 
 =end text
@@ -368,25 +380,32 @@ an int
 
 Input for hisat2.
 ws_name = the workspace name provided by the narrative for storing output.
-sampleset_ref = the workspace reference for the sampleset of reads to align.
+sampleset_ref = the workspace reference for either the reads library or set of reads libraries to align.
+              accepted types: KBaseSets.ReadsSet, KBaseRNASeq.RNASeqSampleSet,
+                              KBaseAssembly.SingleEndLibrary, KBaseAssembly.PairedEndLibrary,
+                              KBaseFile.SingleEndLibrary, KBaseFile.PairedEndLibrary
 genome_ref = the workspace reference for the reference genome that HISAT2 will align against.
-alignmentset_name = the name of the alignment set object to create.
-num_threads = the number of threads to tell hisat to use (NOT USER SET?)
+num_threads = the number of threads to tell hisat to use (default 2)
 quality_score = one of phred33 or phred64
-skip =
-trim3 =
-trim5 =
-np =
-minins =
-maxins =
-orientation =
-min_intron_length =
-max_intron_length =
-no_spliced_alignment =
-transcriptome_mapping_only =
-tailor_alignments =
+skip = number of initial reads to skip (default 0)
+trim3 = number of bases to trim off of the 3' end of each read (default 0)
+trim5 = number of bases to trim off of the 5' end of each read (default 0)
+np = penalty for positions wither the read and/or the reference are an ambiguous character (default 1)
+minins = minimum fragment length for valid paired-end alignments. only used if no_spliced_alignment is true
+maxins = maximum fragment length for valid paired-end alignments. only used if no_spliced_alignment is true
+orientation = orientation of each member of paired-end reads. valid values = "fr, rf, ff"
+min_intron_length = sets minimum intron length (default 20)
+max_intron_length = sets maximum intron length (default 500,000)
+no_spliced_alignment = disable spliced alignment
+transcriptome_mapping_only = only report alignments with known transcripts
+tailor_alignments = report alignments tailored for either cufflinks or stringtie
 condition = a string stating the experimental condition of the reads. REQUIRED for single reads,
             ignored for sets.
+build_report = 1 if we build a report, 0 otherwise. (default 1) (shouldn't be user set - mainly used for subtasks)
+output naming:
+    alignment_suffix is appended to the name of each individual reads object name (just the one if
+    it's a simple input of a single reads library, but to each if it's a set)
+    alignmentset_suffix is appended to the name of the reads set, if a set is passed.
 
 
 =item Definition
@@ -396,7 +415,8 @@ condition = a string stating the experimental condition of the reads. REQUIRED f
 <pre>
 a reference to a hash where the following keys are defined:
 ws_name has a value which is a string
-alignmentset_name has a value which is a string
+alignment_suffix has a value which is a string
+alignmentset_suffix has a value which is a string
 sampleset_ref has a value which is a string
 condition has a value which is a string
 genome_ref has a value which is a string
@@ -414,6 +434,7 @@ max_intron_length has a value which is an int
 no_spliced_alignment has a value which is a kb_hisat2.bool
 transcriptome_mapping_only has a value which is a kb_hisat2.bool
 tailor_alignments has a value which is a string
+build_report has a value which is a kb_hisat2.bool
 
 </pre>
 
@@ -423,7 +444,8 @@ tailor_alignments has a value which is a string
 
 a reference to a hash where the following keys are defined:
 ws_name has a value which is a string
-alignmentset_name has a value which is a string
+alignment_suffix has a value which is a string
+alignmentset_suffix has a value which is a string
 sampleset_ref has a value which is a string
 condition has a value which is a string
 genome_ref has a value which is a string
@@ -441,6 +463,46 @@ max_intron_length has a value which is an int
 no_spliced_alignment has a value which is a kb_hisat2.bool
 transcriptome_mapping_only has a value which is a kb_hisat2.bool
 tailor_alignments has a value which is a string
+build_report has a value which is a kb_hisat2.bool
+
+
+=end text
+
+=back
+
+
+
+=head2 AlignmentObj
+
+=over 4
+
+
+
+=item Description
+
+Created alignment object returned.
+alignment_ref = the workspace reference of the new alignment object
+name = the name of the new object, for convenience.
+
+
+=item Definition
+
+=begin html
+
+<pre>
+a reference to a hash where the following keys are defined:
+alignment_ref has a value which is a string
+name has a value which is a string
+
+</pre>
+
+=end html
+
+=begin text
+
+a reference to a hash where the following keys are defined:
+alignment_ref has a value which is a string
+name has a value which is a string
 
 
 =end text
@@ -458,7 +520,9 @@ tailor_alignments has a value which is a string
 =item Description
 
 Output for hisat2.
-alignment_ref: can be either an Alignment or AlignmentSet, depending on inputs.
+alignmentset_ref if an alignment set is created
+alignment_objs for each individual alignment created. The keys are the references to the reads
+    object being aligned.
 
 
 =item Definition
@@ -469,7 +533,8 @@ alignment_ref: can be either an Alignment or AlignmentSet, depending on inputs.
 a reference to a hash where the following keys are defined:
 report_name has a value which is a string
 report_ref has a value which is a string
-alignment_ref has a value which is a string
+alignmentset_ref has a value which is a string
+alignment_objs has a value which is a reference to a hash where the key is a string and the value is a kb_hisat2.AlignmentObj
 
 </pre>
 
@@ -480,7 +545,8 @@ alignment_ref has a value which is a string
 a reference to a hash where the following keys are defined:
 report_name has a value which is a string
 report_ref has a value which is a string
-alignment_ref has a value which is a string
+alignmentset_ref has a value which is a string
+alignment_objs has a value which is a reference to a hash where the key is a string and the value is a kb_hisat2.AlignmentObj
 
 
 =end text

--- a/lib/kb_hisat2/kb_hisat2Client.py
+++ b/lib/kb_hisat2/kb_hisat2Client.py
@@ -37,35 +37,63 @@ class kb_hisat2(object):
         """
         :param params: instance of type "Hisat2Params" (Input for hisat2.
            ws_name = the workspace name provided by the narrative for storing
-           output. sampleset_ref = the workspace reference for the sampleset
-           of reads to align. genome_ref = the workspace reference for the
-           reference genome that HISAT2 will align against. alignmentset_name
-           = the name of the alignment set object to create. num_threads =
-           the number of threads to tell hisat to use (NOT USER SET?)
-           quality_score = one of phred33 or phred64 skip = trim3 = trim5 =
-           np = minins = maxins = orientation = min_intron_length =
-           max_intron_length = no_spliced_alignment =
-           transcriptome_mapping_only = tailor_alignments = condition = a
-           string stating the experimental condition of the reads. REQUIRED
-           for single reads, ignored for sets.) -> structure: parameter
-           "ws_name" of String, parameter "alignmentset_name" of String,
-           parameter "sampleset_ref" of String, parameter "condition" of
-           String, parameter "genome_ref" of String, parameter "num_threads"
-           of Long, parameter "quality_score" of String, parameter "skip" of
-           Long, parameter "trim3" of Long, parameter "trim5" of Long,
-           parameter "np" of Long, parameter "minins" of Long, parameter
-           "maxins" of Long, parameter "orientation" of String, parameter
-           "min_intron_length" of Long, parameter "max_intron_length" of
-           Long, parameter "no_spliced_alignment" of type "bool" (indicates
-           true or false values, false <= 0, true >=1), parameter
+           output. sampleset_ref = the workspace reference for either the
+           reads library or set of reads libraries to align. accepted types:
+           KBaseSets.ReadsSet, KBaseRNASeq.RNASeqSampleSet,
+           KBaseAssembly.SingleEndLibrary, KBaseAssembly.PairedEndLibrary,
+           KBaseFile.SingleEndLibrary, KBaseFile.PairedEndLibrary genome_ref
+           = the workspace reference for the reference genome that HISAT2
+           will align against. num_threads = the number of threads to tell
+           hisat to use (default 2) quality_score = one of phred33 or phred64
+           skip = number of initial reads to skip (default 0) trim3 = number
+           of bases to trim off of the 3' end of each read (default 0) trim5
+           = number of bases to trim off of the 5' end of each read (default
+           0) np = penalty for positions wither the read and/or the reference
+           are an ambiguous character (default 1) minins = minimum fragment
+           length for valid paired-end alignments. only used if
+           no_spliced_alignment is true maxins = maximum fragment length for
+           valid paired-end alignments. only used if no_spliced_alignment is
+           true orientation = orientation of each member of paired-end reads.
+           valid values = "fr, rf, ff" min_intron_length = sets minimum
+           intron length (default 20) max_intron_length = sets maximum intron
+           length (default 500,000) no_spliced_alignment = disable spliced
+           alignment transcriptome_mapping_only = only report alignments with
+           known transcripts tailor_alignments = report alignments tailored
+           for either cufflinks or stringtie condition = a string stating the
+           experimental condition of the reads. REQUIRED for single reads,
+           ignored for sets. build_report = 1 if we build a report, 0
+           otherwise. (default 1) (shouldn't be user set - mainly used for
+           subtasks) output naming: alignment_suffix is appended to the name
+           of each individual reads object name (just the one if it's a
+           simple input of a single reads library, but to each if it's a set)
+           alignmentset_suffix is appended to the name of the reads set, if a
+           set is passed.) -> structure: parameter "ws_name" of String,
+           parameter "alignment_suffix" of String, parameter
+           "alignmentset_suffix" of String, parameter "sampleset_ref" of
+           String, parameter "condition" of String, parameter "genome_ref" of
+           String, parameter "num_threads" of Long, parameter "quality_score"
+           of String, parameter "skip" of Long, parameter "trim3" of Long,
+           parameter "trim5" of Long, parameter "np" of Long, parameter
+           "minins" of Long, parameter "maxins" of Long, parameter
+           "orientation" of String, parameter "min_intron_length" of Long,
+           parameter "max_intron_length" of Long, parameter
+           "no_spliced_alignment" of type "bool" (indicates true or false
+           values, false <= 0, true >=1), parameter
            "transcriptome_mapping_only" of type "bool" (indicates true or
            false values, false <= 0, true >=1), parameter "tailor_alignments"
-           of String
+           of String, parameter "build_report" of type "bool" (indicates true
+           or false values, false <= 0, true >=1)
         :returns: instance of type "Hisat2Output" (Output for hisat2.
-           alignment_ref: can be either an Alignment or AlignmentSet,
-           depending on inputs.) -> structure: parameter "report_name" of
-           String, parameter "report_ref" of String, parameter
-           "alignment_ref" of String
+           alignmentset_ref if an alignment set is created alignment_objs for
+           each individual alignment created. The keys are the references to
+           the reads object being aligned.) -> structure: parameter
+           "report_name" of String, parameter "report_ref" of String,
+           parameter "alignmentset_ref" of String, parameter "alignment_objs"
+           of mapping from String to type "AlignmentObj" (Created alignment
+           object returned. alignment_ref = the workspace reference of the
+           new alignment object name = the name of the new object, for
+           convenience.) -> structure: parameter "alignment_ref" of String,
+           parameter "name" of String
         """
         return self._client.call_method(
             'kb_hisat2.run_hisat2',

--- a/lib/kb_hisat2/kb_hisat2Impl.py
+++ b/lib/kb_hisat2/kb_hisat2Impl.py
@@ -31,9 +31,9 @@ class kb_hisat2:
     # state. A method could easily clobber the state set by another while
     # the latter method is running.
     ######################################### noqa
-    VERSION = "0.0.1"
+    VERSION = "0.1.10"
     GIT_URL = "https://github.com/briehl/kb_hisat2"
-    GIT_COMMIT_HASH = "1e57d0568cbf3fe295cb5f0346784bc0c4ceac9e"
+    GIT_COMMIT_HASH = "6ef455215a54740f680b3297303821abfefc6eab"
 
     #BEGIN_CLASS_HEADER
     # Class variables and functions can be defined in this block
@@ -59,35 +59,63 @@ class kb_hisat2:
         """
         :param params: instance of type "Hisat2Params" (Input for hisat2.
            ws_name = the workspace name provided by the narrative for storing
-           output. sampleset_ref = the workspace reference for the sampleset
-           of reads to align. genome_ref = the workspace reference for the
-           reference genome that HISAT2 will align against. alignmentset_name
-           = the name of the alignment set object to create. num_threads =
-           the number of threads to tell hisat to use (NOT USER SET?)
-           quality_score = one of phred33 or phred64 skip = trim3 = trim5 =
-           np = minins = maxins = orientation = min_intron_length =
-           max_intron_length = no_spliced_alignment =
-           transcriptome_mapping_only = tailor_alignments = condition = a
-           string stating the experimental condition of the reads. REQUIRED
-           for single reads, ignored for sets.) -> structure: parameter
-           "ws_name" of String, parameter "alignmentset_name" of String,
-           parameter "sampleset_ref" of String, parameter "condition" of
-           String, parameter "genome_ref" of String, parameter "num_threads"
-           of Long, parameter "quality_score" of String, parameter "skip" of
-           Long, parameter "trim3" of Long, parameter "trim5" of Long,
-           parameter "np" of Long, parameter "minins" of Long, parameter
-           "maxins" of Long, parameter "orientation" of String, parameter
-           "min_intron_length" of Long, parameter "max_intron_length" of
-           Long, parameter "no_spliced_alignment" of type "bool" (indicates
-           true or false values, false <= 0, true >=1), parameter
+           output. sampleset_ref = the workspace reference for either the
+           reads library or set of reads libraries to align. accepted types:
+           KBaseSets.ReadsSet, KBaseRNASeq.RNASeqSampleSet,
+           KBaseAssembly.SingleEndLibrary, KBaseAssembly.PairedEndLibrary,
+           KBaseFile.SingleEndLibrary, KBaseFile.PairedEndLibrary genome_ref
+           = the workspace reference for the reference genome that HISAT2
+           will align against. num_threads = the number of threads to tell
+           hisat to use (default 2) quality_score = one of phred33 or phred64
+           skip = number of initial reads to skip (default 0) trim3 = number
+           of bases to trim off of the 3' end of each read (default 0) trim5
+           = number of bases to trim off of the 5' end of each read (default
+           0) np = penalty for positions wither the read and/or the reference
+           are an ambiguous character (default 1) minins = minimum fragment
+           length for valid paired-end alignments. only used if
+           no_spliced_alignment is true maxins = maximum fragment length for
+           valid paired-end alignments. only used if no_spliced_alignment is
+           true orientation = orientation of each member of paired-end reads.
+           valid values = "fr, rf, ff" min_intron_length = sets minimum
+           intron length (default 20) max_intron_length = sets maximum intron
+           length (default 500,000) no_spliced_alignment = disable spliced
+           alignment transcriptome_mapping_only = only report alignments with
+           known transcripts tailor_alignments = report alignments tailored
+           for either cufflinks or stringtie condition = a string stating the
+           experimental condition of the reads. REQUIRED for single reads,
+           ignored for sets. build_report = 1 if we build a report, 0
+           otherwise. (default 1) (shouldn't be user set - mainly used for
+           subtasks) output naming: alignment_suffix is appended to the name
+           of each individual reads object name (just the one if it's a
+           simple input of a single reads library, but to each if it's a set)
+           alignmentset_suffix is appended to the name of the reads set, if a
+           set is passed.) -> structure: parameter "ws_name" of String,
+           parameter "alignment_suffix" of String, parameter
+           "alignmentset_suffix" of String, parameter "sampleset_ref" of
+           String, parameter "condition" of String, parameter "genome_ref" of
+           String, parameter "num_threads" of Long, parameter "quality_score"
+           of String, parameter "skip" of Long, parameter "trim3" of Long,
+           parameter "trim5" of Long, parameter "np" of Long, parameter
+           "minins" of Long, parameter "maxins" of Long, parameter
+           "orientation" of String, parameter "min_intron_length" of Long,
+           parameter "max_intron_length" of Long, parameter
+           "no_spliced_alignment" of type "bool" (indicates true or false
+           values, false <= 0, true >=1), parameter
            "transcriptome_mapping_only" of type "bool" (indicates true or
            false values, false <= 0, true >=1), parameter "tailor_alignments"
-           of String
+           of String, parameter "build_report" of type "bool" (indicates true
+           or false values, false <= 0, true >=1)
         :returns: instance of type "Hisat2Output" (Output for hisat2.
-           alignment_ref: can be either an Alignment or AlignmentSet,
-           depending on inputs.) -> structure: parameter "report_name" of
-           String, parameter "report_ref" of String, parameter
-           "alignment_ref" of String
+           alignmentset_ref if an alignment set is created alignment_objs for
+           each individual alignment created. The keys are the references to
+           the reads object being aligned.) -> structure: parameter
+           "report_name" of String, parameter "report_ref" of String,
+           parameter "alignmentset_ref" of String, parameter "alignment_objs"
+           of mapping from String to type "AlignmentObj" (Created alignment
+           object returned. alignment_ref = the workspace reference of the
+           new alignment object name = the name of the new object, for
+           convenience.) -> structure: parameter "alignment_ref" of String,
+           parameter "name" of String
         """
         # ctx is the context object
         # return variables are: returnVal
@@ -118,20 +146,21 @@ class kb_hisat2:
         #  1. make a list of tasks to send to KBParallel.
         #  2. add a flag to not make a report for each subtask.
         #  3. make the report when it's all done.
-        alignment_set_ref = None
+        alignmentset_ref = None
         if len(reads_refs) == 1:
-            (alignments, output_ref) = hs_runner.run_single(reads_refs[0], params)
+            # if params["sampleset_ref"] is a Set type, this will make a set on output.
+            # otherwise, it doesn't.
+            (alignments, output_ref, alignmentset_ref) = hs_runner.run_single(reads_refs[0], params)
         else:
-            (alignments, alignment_set_ref) = hs_runner.run_batch(reads_refs, params)
+            (alignments, alignmentset_ref) = hs_runner.run_batch(reads_refs, params)
 
         if params.get("build_report", 0) == 1:
             report_info = hs_runner.build_report(params, reads_refs, alignments,
-                                                 alignment_set=alignment_set_ref)
+                                                 alignment_set=alignmentset_ref)
             returnVal["report_ref"] = report_info["ref"]
             returnVal["report_name"] = report_info["name"]
         returnVal["alignment_objs"] = alignments
-        returnVal["alignment_ref"] = output_ref
-        returnVal["alignment_name"] = params["alignmentset_name"]
+        returnVal["alignmentset_ref"] = alignmentset_ref
         #END run_hisat2
 
         # At some point might do deeper type checking...

--- a/lib/kb_hisat2/util.py
+++ b/lib/kb_hisat2/util.py
@@ -42,9 +42,9 @@ def check_hisat2_parameters(params, ws_url):
     if "ws_name" not in params or not valid_string(params["ws_name"]):
         errors.append("Parameter ws_name must be a valid workspace "
                       "name, not {}".format(params.get("ws_name", None)))
-    if "alignmentset_name" not in params or not valid_string(params["alignmentset_name"]):
-        errors.append("Parameter alignmentset_name must be a valid Workspace object string, "
-                      "not {}".format(params.get("alignmentset_name", None)))
+    if "alignment_suffix" not in params or not valid_string(params["alignment_suffix"]):
+        errors.append("Parameter alignment_suffix must be a valid Workspace object string, "
+                      "not {}".format(params.get("alignment_suffix", None)))
     if "sampleset_ref" not in params or not valid_string(params["sampleset_ref"], is_ref=True):
         errors.append("Parameter sampleset_ref must be a valid Workspace object reference, "
                       "not {}".format(params.get("sampleset_ref", None)))
@@ -78,6 +78,10 @@ def check_reference(ref):
     return True
 
 
+def is_set(ref, ws_url):
+    return check_ref_type(ref, ["sampleset", "readsset"], ws_url)
+
+
 def check_ref_type(ref, allowed_types, ws_url):
     """
     Validates the object type of ref against the list of allowed types. If it passes, this
@@ -85,11 +89,11 @@ def check_ref_type(ref, allowed_types, ws_url):
     Really, all this does is verify that at least one of the strings in allowed_types is
     a substring of the ref object type name.
     Ex1:
-    ref = "KBaseGenomes.Genome-4.0"
+    ref = 11/22/33, which is a "KBaseGenomes.Genome-4.0"
     allowed_types = ["assembly", "KBaseFile.Assembly"]
     returns False
     Ex2:
-    ref = "KBaseGenomes.Genome-4.0"
+    ref = 44/55/66, which is a "KBaseGenomes.Genome-4.0"
     allowed_types = ["assembly", "genome"]
     returns True
     """
@@ -126,7 +130,8 @@ def get_object_names(ref_list, ws_url):
     info = ws.get_object_info3({"objects": obj_ids})
     name_map = dict()
     # might be in a data palette, so we can't just use the ref.
-    # we already have the refs as passed previously, so use those for mapping.
+    # we already have the refs as passed previously, so use those for mapping, as they're in
+    # the same order as what's returned.
     for i in range(len(info["infos"])):
         name_map[ref_list[i]] = info["infos"][i][1]
     return name_map

--- a/lib/src/us/kbase/kbhisat2/AlignmentObj.java
+++ b/lib/src/us/kbase/kbhisat2/AlignmentObj.java
@@ -1,0 +1,82 @@
+
+package us.kbase.kbhisat2;
+
+import java.util.HashMap;
+import java.util.Map;
+import javax.annotation.Generated;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+
+/**
+ * <p>Original spec-file type: AlignmentObj</p>
+ * <pre>
+ * Created alignment object returned.
+ * alignment_ref = the workspace reference of the new alignment object
+ * name = the name of the new object, for convenience.
+ * </pre>
+ * 
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Generated("com.googlecode.jsonschema2pojo")
+@JsonPropertyOrder({
+    "alignment_ref",
+    "name"
+})
+public class AlignmentObj {
+
+    @JsonProperty("alignment_ref")
+    private String alignmentRef;
+    @JsonProperty("name")
+    private String name;
+    private Map<String, Object> additionalProperties = new HashMap<String, Object>();
+
+    @JsonProperty("alignment_ref")
+    public String getAlignmentRef() {
+        return alignmentRef;
+    }
+
+    @JsonProperty("alignment_ref")
+    public void setAlignmentRef(String alignmentRef) {
+        this.alignmentRef = alignmentRef;
+    }
+
+    public AlignmentObj withAlignmentRef(String alignmentRef) {
+        this.alignmentRef = alignmentRef;
+        return this;
+    }
+
+    @JsonProperty("name")
+    public String getName() {
+        return name;
+    }
+
+    @JsonProperty("name")
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public AlignmentObj withName(String name) {
+        this.name = name;
+        return this;
+    }
+
+    @JsonAnyGetter
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperties(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+
+    @Override
+    public String toString() {
+        return ((((((("AlignmentObj"+" [alignmentRef=")+ alignmentRef)+", name=")+ name)+", additionalProperties=")+ additionalProperties)+"]");
+    }
+
+}

--- a/lib/src/us/kbase/kbhisat2/Hisat2Output.java
+++ b/lib/src/us/kbase/kbhisat2/Hisat2Output.java
@@ -15,7 +15,9 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  * <p>Original spec-file type: Hisat2Output</p>
  * <pre>
  * Output for hisat2.
- * alignment_ref: can be either an Alignment or AlignmentSet, depending on inputs.
+ * alignmentset_ref if an alignment set is created
+ * alignment_objs for each individual alignment created. The keys are the references to the reads
+ *     object being aligned.
  * </pre>
  * 
  */
@@ -24,76 +26,94 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 @JsonPropertyOrder({
     "report_name",
     "report_ref",
-    "alignment_ref"
+    "alignmentset_ref",
+    "alignment_objs"
 })
 public class Hisat2Output {
 
     @JsonProperty("report_name")
-    private String reportName;
+    private java.lang.String reportName;
     @JsonProperty("report_ref")
-    private String reportRef;
-    @JsonProperty("alignment_ref")
-    private String alignmentRef;
-    private Map<String, Object> additionalProperties = new HashMap<String, Object>();
+    private java.lang.String reportRef;
+    @JsonProperty("alignmentset_ref")
+    private java.lang.String alignmentsetRef;
+    @JsonProperty("alignment_objs")
+    private Map<String, AlignmentObj> alignmentObjs;
+    private Map<java.lang.String, Object> additionalProperties = new HashMap<java.lang.String, Object>();
 
     @JsonProperty("report_name")
-    public String getReportName() {
+    public java.lang.String getReportName() {
         return reportName;
     }
 
     @JsonProperty("report_name")
-    public void setReportName(String reportName) {
+    public void setReportName(java.lang.String reportName) {
         this.reportName = reportName;
     }
 
-    public Hisat2Output withReportName(String reportName) {
+    public Hisat2Output withReportName(java.lang.String reportName) {
         this.reportName = reportName;
         return this;
     }
 
     @JsonProperty("report_ref")
-    public String getReportRef() {
+    public java.lang.String getReportRef() {
         return reportRef;
     }
 
     @JsonProperty("report_ref")
-    public void setReportRef(String reportRef) {
+    public void setReportRef(java.lang.String reportRef) {
         this.reportRef = reportRef;
     }
 
-    public Hisat2Output withReportRef(String reportRef) {
+    public Hisat2Output withReportRef(java.lang.String reportRef) {
         this.reportRef = reportRef;
         return this;
     }
 
-    @JsonProperty("alignment_ref")
-    public String getAlignmentRef() {
-        return alignmentRef;
+    @JsonProperty("alignmentset_ref")
+    public java.lang.String getAlignmentsetRef() {
+        return alignmentsetRef;
     }
 
-    @JsonProperty("alignment_ref")
-    public void setAlignmentRef(String alignmentRef) {
-        this.alignmentRef = alignmentRef;
+    @JsonProperty("alignmentset_ref")
+    public void setAlignmentsetRef(java.lang.String alignmentsetRef) {
+        this.alignmentsetRef = alignmentsetRef;
     }
 
-    public Hisat2Output withAlignmentRef(String alignmentRef) {
-        this.alignmentRef = alignmentRef;
+    public Hisat2Output withAlignmentsetRef(java.lang.String alignmentsetRef) {
+        this.alignmentsetRef = alignmentsetRef;
+        return this;
+    }
+
+    @JsonProperty("alignment_objs")
+    public Map<String, AlignmentObj> getAlignmentObjs() {
+        return alignmentObjs;
+    }
+
+    @JsonProperty("alignment_objs")
+    public void setAlignmentObjs(Map<String, AlignmentObj> alignmentObjs) {
+        this.alignmentObjs = alignmentObjs;
+    }
+
+    public Hisat2Output withAlignmentObjs(Map<String, AlignmentObj> alignmentObjs) {
+        this.alignmentObjs = alignmentObjs;
         return this;
     }
 
     @JsonAnyGetter
-    public Map<String, Object> getAdditionalProperties() {
+    public Map<java.lang.String, Object> getAdditionalProperties() {
         return this.additionalProperties;
     }
 
     @JsonAnySetter
-    public void setAdditionalProperties(String name, Object value) {
+    public void setAdditionalProperties(java.lang.String name, Object value) {
         this.additionalProperties.put(name, value);
     }
 
     @Override
-    public String toString() {
-        return ((((((((("Hisat2Output"+" [reportName=")+ reportName)+", reportRef=")+ reportRef)+", alignmentRef=")+ alignmentRef)+", additionalProperties=")+ additionalProperties)+"]");
+    public java.lang.String toString() {
+        return ((((((((((("Hisat2Output"+" [reportName=")+ reportName)+", reportRef=")+ reportRef)+", alignmentsetRef=")+ alignmentsetRef)+", alignmentObjs=")+ alignmentObjs)+", additionalProperties=")+ additionalProperties)+"]");
     }
 
 }

--- a/lib/src/us/kbase/kbhisat2/Hisat2Params.java
+++ b/lib/src/us/kbase/kbhisat2/Hisat2Params.java
@@ -16,25 +16,32 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  * <pre>
  * Input for hisat2.
  * ws_name = the workspace name provided by the narrative for storing output.
- * sampleset_ref = the workspace reference for the sampleset of reads to align.
+ * sampleset_ref = the workspace reference for either the reads library or set of reads libraries to align.
+ *               accepted types: KBaseSets.ReadsSet, KBaseRNASeq.RNASeqSampleSet,
+ *                               KBaseAssembly.SingleEndLibrary, KBaseAssembly.PairedEndLibrary,
+ *                               KBaseFile.SingleEndLibrary, KBaseFile.PairedEndLibrary
  * genome_ref = the workspace reference for the reference genome that HISAT2 will align against.
- * alignmentset_name = the name of the alignment set object to create.
- * num_threads = the number of threads to tell hisat to use (NOT USER SET?)
+ * num_threads = the number of threads to tell hisat to use (default 2)
  * quality_score = one of phred33 or phred64
- * skip =
- * trim3 =
- * trim5 =
- * np =
- * minins =
- * maxins =
- * orientation =
- * min_intron_length =
- * max_intron_length =
- * no_spliced_alignment =
- * transcriptome_mapping_only =
- * tailor_alignments =
+ * skip = number of initial reads to skip (default 0)
+ * trim3 = number of bases to trim off of the 3' end of each read (default 0)
+ * trim5 = number of bases to trim off of the 5' end of each read (default 0)
+ * np = penalty for positions wither the read and/or the reference are an ambiguous character (default 1)
+ * minins = minimum fragment length for valid paired-end alignments. only used if no_spliced_alignment is true
+ * maxins = maximum fragment length for valid paired-end alignments. only used if no_spliced_alignment is true
+ * orientation = orientation of each member of paired-end reads. valid values = "fr, rf, ff"
+ * min_intron_length = sets minimum intron length (default 20)
+ * max_intron_length = sets maximum intron length (default 500,000)
+ * no_spliced_alignment = disable spliced alignment
+ * transcriptome_mapping_only = only report alignments with known transcripts
+ * tailor_alignments = report alignments tailored for either cufflinks or stringtie
  * condition = a string stating the experimental condition of the reads. REQUIRED for single reads,
  *             ignored for sets.
+ * build_report = 1 if we build a report, 0 otherwise. (default 1) (shouldn't be user set - mainly used for subtasks)
+ * output naming:
+ *     alignment_suffix is appended to the name of each individual reads object name (just the one if
+ *     it's a simple input of a single reads library, but to each if it's a set)
+ *     alignmentset_suffix is appended to the name of the reads set, if a set is passed.
  * </pre>
  * 
  */
@@ -42,7 +49,8 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 @Generated("com.googlecode.jsonschema2pojo")
 @JsonPropertyOrder({
     "ws_name",
-    "alignmentset_name",
+    "alignment_suffix",
+    "alignmentset_suffix",
     "sampleset_ref",
     "condition",
     "genome_ref",
@@ -59,14 +67,17 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
     "max_intron_length",
     "no_spliced_alignment",
     "transcriptome_mapping_only",
-    "tailor_alignments"
+    "tailor_alignments",
+    "build_report"
 })
 public class Hisat2Params {
 
     @JsonProperty("ws_name")
     private String wsName;
-    @JsonProperty("alignmentset_name")
-    private String alignmentsetName;
+    @JsonProperty("alignment_suffix")
+    private String alignmentSuffix;
+    @JsonProperty("alignmentset_suffix")
+    private String alignmentsetSuffix;
     @JsonProperty("sampleset_ref")
     private String samplesetRef;
     @JsonProperty("condition")
@@ -101,6 +112,8 @@ public class Hisat2Params {
     private Long transcriptomeMappingOnly;
     @JsonProperty("tailor_alignments")
     private String tailorAlignments;
+    @JsonProperty("build_report")
+    private Long buildReport;
     private Map<String, Object> additionalProperties = new HashMap<String, Object>();
 
     @JsonProperty("ws_name")
@@ -118,18 +131,33 @@ public class Hisat2Params {
         return this;
     }
 
-    @JsonProperty("alignmentset_name")
-    public String getAlignmentsetName() {
-        return alignmentsetName;
+    @JsonProperty("alignment_suffix")
+    public String getAlignmentSuffix() {
+        return alignmentSuffix;
     }
 
-    @JsonProperty("alignmentset_name")
-    public void setAlignmentsetName(String alignmentsetName) {
-        this.alignmentsetName = alignmentsetName;
+    @JsonProperty("alignment_suffix")
+    public void setAlignmentSuffix(String alignmentSuffix) {
+        this.alignmentSuffix = alignmentSuffix;
     }
 
-    public Hisat2Params withAlignmentsetName(String alignmentsetName) {
-        this.alignmentsetName = alignmentsetName;
+    public Hisat2Params withAlignmentSuffix(String alignmentSuffix) {
+        this.alignmentSuffix = alignmentSuffix;
+        return this;
+    }
+
+    @JsonProperty("alignmentset_suffix")
+    public String getAlignmentsetSuffix() {
+        return alignmentsetSuffix;
+    }
+
+    @JsonProperty("alignmentset_suffix")
+    public void setAlignmentsetSuffix(String alignmentsetSuffix) {
+        this.alignmentsetSuffix = alignmentsetSuffix;
+    }
+
+    public Hisat2Params withAlignmentsetSuffix(String alignmentsetSuffix) {
+        this.alignmentsetSuffix = alignmentsetSuffix;
         return this;
     }
 
@@ -388,6 +416,21 @@ public class Hisat2Params {
         return this;
     }
 
+    @JsonProperty("build_report")
+    public Long getBuildReport() {
+        return buildReport;
+    }
+
+    @JsonProperty("build_report")
+    public void setBuildReport(Long buildReport) {
+        this.buildReport = buildReport;
+    }
+
+    public Hisat2Params withBuildReport(Long buildReport) {
+        this.buildReport = buildReport;
+        return this;
+    }
+
     @JsonAnyGetter
     public Map<String, Object> getAdditionalProperties() {
         return this.additionalProperties;
@@ -400,7 +443,7 @@ public class Hisat2Params {
 
     @Override
     public String toString() {
-        return ((((((((((((((((((((((((((((((((((((((((("Hisat2Params"+" [wsName=")+ wsName)+", alignmentsetName=")+ alignmentsetName)+", samplesetRef=")+ samplesetRef)+", condition=")+ condition)+", genomeRef=")+ genomeRef)+", numThreads=")+ numThreads)+", qualityScore=")+ qualityScore)+", skip=")+ skip)+", trim3=")+ trim3)+", trim5=")+ trim5)+", np=")+ np)+", minins=")+ minins)+", maxins=")+ maxins)+", orientation=")+ orientation)+", minIntronLength=")+ minIntronLength)+", maxIntronLength=")+ maxIntronLength)+", noSplicedAlignment=")+ noSplicedAlignment)+", transcriptomeMappingOnly=")+ transcriptomeMappingOnly)+", tailorAlignments=")+ tailorAlignments)+", additionalProperties=")+ additionalProperties)+"]");
+        return ((((((((((((((((((((((((((((((((((((((((((((("Hisat2Params"+" [wsName=")+ wsName)+", alignmentSuffix=")+ alignmentSuffix)+", alignmentsetSuffix=")+ alignmentsetSuffix)+", samplesetRef=")+ samplesetRef)+", condition=")+ condition)+", genomeRef=")+ genomeRef)+", numThreads=")+ numThreads)+", qualityScore=")+ qualityScore)+", skip=")+ skip)+", trim3=")+ trim3)+", trim5=")+ trim5)+", np=")+ np)+", minins=")+ minins)+", maxins=")+ maxins)+", orientation=")+ orientation)+", minIntronLength=")+ minIntronLength)+", maxIntronLength=")+ maxIntronLength)+", noSplicedAlignment=")+ noSplicedAlignment)+", transcriptomeMappingOnly=")+ transcriptomeMappingOnly)+", tailorAlignments=")+ tailorAlignments)+", buildReport=")+ buildReport)+", additionalProperties=")+ additionalProperties)+"]");
     }
 
 }

--- a/ui/narrative/methods/align_reads_using_hisat2/display.yaml
+++ b/ui/narrative/methods/align_reads_using_hisat2/display.yaml
@@ -30,12 +30,17 @@ parameters :
         ui-name : |
             Genome
         short-hint : |
-            Select the Genome to align the reads
-    alignment_output :
+            Select the Genome to align the reads.
+    alignmentset_suffix :
         ui-name : |
-            Alignment Output
+            Alignment Set Suffix
         short-hint : |
-            Name the alignment object
+            Provide a suffix that will appended to the name of the set of reads used as input.
+    alignment_suffix :
+        ui-name : |
+            Alignment Suffix
+        short-hint : |
+            Provide a suffix that will be appended to the name of each reads library aligned.
     quality_score :
         ui-name : |
             Alignment Quality Score Type

--- a/ui/narrative/methods/align_reads_using_hisat2/spec.json
+++ b/ui/narrative/methods/align_reads_using_hisat2/spec.json
@@ -26,22 +26,26 @@
         "default_values" : [ "" ],
         "field_type" : "text",
         "text_options" : {
-            "valid_ws_types" : ["KBaseGenomes.Genome" ]
+            "valid_ws_types" : [ "KBaseGenomes.Genome" ]
         }
     }, {
-        "id": "alignment_output",
-        "optional": false,
-        "advanced": false,
-        "allow_multiple": false,
-        "default_values": [""],
-        "field_type": "text",
-        "text_options": {
-            "is_output_name": true
-        }
+        "id" : "alignment_suffix",
+        "optional" : false,
+        "advanced" : true,
+        "allow_multiple" : false,
+        "default_values" : [ "_alignment" ],
+        "field_type" : "text"
+    }, {
+        "id" : "alignmentset_suffix",
+        "optional" : true,
+        "advanced" : true,
+        "allow_multiple" : false,
+        "default_values" : [ "_alignment_set" ],
+        "field_type" : "text"
     }, {
         "id": "reads_condition",
         "optional" : true,
-        "advanced": false,
+        "advanced": true,
         "allow_multiple": false,
         "default_values": [ "unspecified" ],
         "field_type": "text"
@@ -199,6 +203,12 @@
                     "target_property" : "genome_ref",
                     "target_type_transform": "resolved-ref"
                 }, {
+                    "input_parameter" : "alignment_suffix",
+                    "target_property" : "alignment_suffix"
+                },{
+                    "input_parameter" : "alignmentset_suffix",
+                    "target_property" : "alignmentset_suffix"
+                },{
                     "input_parameter" : "quality_score",
                     "target_property" : "quality_score"
                 }, {
@@ -232,16 +242,13 @@
                     "input_parameter" : "orientation",
                     "target_property" : "orientation"
                 }, {
-                    "input_parameter" : "alignment_output",
-                    "target_property" : "alignmentset_name"
-                }, {
                     "input_parameter" : "reads_condition",
                     "target_property" : "condition"
                 }
             ],
             "output_mapping" : [{
-                "service_method_output_path": [0,"alignment_ref"],
-                "target_property": "output"
+                "service_method_output_path": [0, "alignmentset_ref"],
+                "target_property": "alignmentset_ref"
             }, {
                 "narrative_system_variable": "workspace",
                 "target_property": "workspace"


### PR DESCRIPTION
1. Remove user-allowed output naming.
2. Add user-set suffixes for output objects. Now, if the input is a reads set named `My_Reads`, composed of `reads_wt_1` and `reads_wt_2`, the alignment set will be named `My_Reads_alignment_set` (or however the user chooses), and each individual alignment object will be named `reads_wt_1_alignment` and `reads_wt_2_alignment` (again, according to the parameter).
3. Fix behavior for aligning a set containing a single reads reference. Now it makes an AlignmentSet with a single Alignment object, as well as the Alignment object itself.
4. Fix tests to be more thorough with checking the outputs.
5. Update the spec to have more details of the output objects.

new version = 0.2.0